### PR TITLE
Allows for vertical scrolling

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -14,7 +14,7 @@ main {
 	height: -webkit-fill-available;
 	max-height: 100vh;
 	overflow-x: auto;
-	overflow-y: hidden;
+	overflow-y: auto;
 }
 
 .b-example-divider {


### PR DESCRIPTION
The window currently does not allow for vertical scrolling. As a result, the endpoint list and the info panel will be clipped if the content exceeds the height of the window.

Ideally, each of the two sections would be independently scrollable, but this should resolve the immediate issue of being unable to see content at all if it exceeds your screen's height.